### PR TITLE
Verbose Raid Traffic

### DIFF
--- a/Button.lua
+++ b/Button.lua
@@ -11,7 +11,7 @@ function CEPGP_ListButton_OnClick(obj)
 		_G["CEPGP_context_reason"]:Show();
 		_G["CEPGP_context_popup_reason"]:Show();
 	end
-	
+
 	if strfind(obj, "Delete") then
 		local name = _G["CEPGP_overrideButton" .. _G[obj]:GetParent():GetID() .. "item"]:GetText();
 		OVERRIDE_INDEX[name] = nil;
@@ -19,7 +19,7 @@ function CEPGP_ListButton_OnClick(obj)
 		CEPGP_UpdateOverrideScrollBar();
 		return;
 	end
-	
+
 	if obj == "CEPGP_options_standby_ep_award" then
 		ShowUIPanel(CEPGP_context_popup);
 		ShowUIPanel(CEPGP_context_amount);
@@ -43,7 +43,7 @@ function CEPGP_ListButton_OnClick(obj)
 															end
 														end);
 		return;
-	
+
 	elseif strfind(obj, "StandbyButton") then
 		local name = _G[_G[_G[obj]:GetName()]:GetParent():GetName() .. "Info"]:GetText();
 		for i = 1, CEPGP_ntgetn(CEPGP_standbyRoster) do
@@ -58,7 +58,7 @@ function CEPGP_ListButton_OnClick(obj)
 		CEPGP_UpdateStandbyScrollBar();
 		return;
 	end
-	
+
 	if obj == "CEPGP_standby_ep_list_add" and (CanEditOfficerNote() or CEPGP_debugMode) then
 		ShowUIPanel(CEPGP_context_popup);
 		CEPGP_context_popup_EP_check:Hide();
@@ -76,7 +76,7 @@ function CEPGP_ListButton_OnClick(obj)
 														end);
 		return;
 	end
-	
+
 	if obj == "CEPGP_standby_ep_list_addbyrank" then
 		CEPGP_standby_addRank:Show();
 	end
@@ -116,12 +116,12 @@ function CEPGP_ListButton_OnClick(obj)
 		CEPGP_standbyRoster = {};
 		CEPGP_UpdateStandbyScrollBar();
 	end
-	
+
 	if not CanEditOfficerNote() and not CEPGP_debugMode then
 		CEPGP_print("You don't have access to modify EPGP", 1);
 		return;
 	end
-	
+
 	--[[ Distribution Menu ]]--
 	if strfind(obj, "LootDistButton") then --A player in the distribution menu is clicked
 		ShowUIPanel(CEPGP_distribute_popup);
@@ -129,7 +129,7 @@ function CEPGP_ListButton_OnClick(obj)
 		CEPGP_distPlayer = _G[_G[obj]:GetName() .. "Info"]:GetText();
 		CEPGP_distribute_popup:SetID(CEPGP_distribute:GetID()); --CEPGP_distribute:GetID gets the ID of the LOOT SLOT. Not the player.
 		return;
-	
+
 		--[[ Guild Menu ]]--
 	elseif strfind(obj, "GuildButton") then --A player from the guild menu is clicked (awards EP)
 		local name = _G[_G[obj]:GetName() .. "Info"]:GetText();
@@ -159,7 +159,7 @@ function CEPGP_ListButton_OnClick(obj)
 															end
 														end);
 		return;
-		
+
 	elseif strfind(obj, "CEPGP_guild_add_EP") then --Click the Add Guild EP button in the Guild menu
 		ShowUIPanel(CEPGP_context_popup);
 		ShowUIPanel(CEPGP_context_amount);
@@ -183,7 +183,7 @@ function CEPGP_ListButton_OnClick(obj)
 															end
 														end);
 		return;
-	
+
 	elseif strfind(obj, "CEPGP_guild_decay") then --Click the Decay Guild EPGP button in the Guild menu
 		ShowUIPanel(CEPGP_context_popup);
 		ShowUIPanel(CEPGP_context_amount);
@@ -207,7 +207,7 @@ function CEPGP_ListButton_OnClick(obj)
 															end
 														end);
 		return;
-		
+
 	elseif strfind(obj, "CEPGP_guild_reset") then --Click the Reset All EPGP Standings button in the Guild menu
 		ShowUIPanel(CEPGP_context_popup);
 		HideUIPanel(CEPGP_context_amount);
@@ -226,7 +226,7 @@ function CEPGP_ListButton_OnClick(obj)
 															CEPGP_resetAll(CEPGP_context_reason:GetText());
 														end)
 		return;
-		
+
 		--[[ Raid Menu ]]--
 	elseif strfind(obj, "RaidButton") then --A player from the raid menu is clicked (awards EP)
 		local name = _G[_G[obj]:GetName() .. "Info"]:GetText();
@@ -260,7 +260,7 @@ function CEPGP_ListButton_OnClick(obj)
 															end
 														end);
 		return;
-	
+
 	elseif strfind(obj, "CEPGP_raid_add_EP") then --Click the Add Raid EP button in the Raid menu
 		ShowUIPanel(CEPGP_context_popup);
 		ShowUIPanel(CEPGP_context_amount);
@@ -279,8 +279,9 @@ function CEPGP_ListButton_OnClick(obj)
 																CEPGP_print("Enter a valid number", true);
 															else
 																PlaySound(799);
-																HideUIPanel(CEPGP_context_popup);
-																CEPGP_AddRaidEP(tonumber(CEPGP_context_amount:GetText()), CEPGP_context_reason:GetText());
+																if CEPGP_AddRaidEP(tonumber(CEPGP_context_amount:GetText()), CEPGP_context_reason:GetText()) then
+																	HideUIPanel(CEPGP_context_popup);
+																end
 															end
 														end);
 		return;
@@ -288,7 +289,7 @@ function CEPGP_ListButton_OnClick(obj)
 end
 
 function CEPGP_setOverrideLink(frame, event)
-	
+
 	if event == "enter" then
 		local _, link = GetItemInfo(frame:GetText());
 		GameTooltip:SetOwner(frame, "ANCHOR_TOPLEFT");
@@ -339,7 +340,7 @@ function CEPGP_restoreDropdownOnClick(self, arg1, arg2, checked)
 end
 
 		--[[ Sync Rank DropDown ]]--
-		
+
 function CEPGP_syncRankDropdown(frame, level, menuList)
 	for i = 1, 10, 1 do
 		if GuildControlGetRankName(i) ~= "" then
@@ -361,7 +362,7 @@ function CEPGP_syncRankChange(self, arg1, arg2, checked)
 end
 
 		--[[ Attendance DropDown ]]--
-		
+
 function CEPGP_attendanceDropdown(frame, level, menuList)
 	local info = {text = "Guild List", value = 0, func = CEPGP_attendanceChange};
 	local entry = UIDropDownMenu_AddButton(info);
@@ -409,7 +410,7 @@ function CEPGP_minThresholdChange(self, value)
 end
 
 		--[[ Default Channel DropDown ]]--
-		
+
 function CEPGP_defChannelDropdown(frame, level, menuList)
 	local channels = {
 		[1] = "Say",
@@ -446,7 +447,7 @@ function CEPGP_defChannelChange(self, value)
 end
 
 		--[[ Loot Response Channel DropDown ]]--
-		
+
 function CEPGP_lootChannelDropdown(frame, level, menuList)
 	local channels = {
 		[1] = "Say",

--- a/CEPGP.toc
+++ b/CEPGP.toc
@@ -2,7 +2,7 @@
 ## Title: Classic EPGP
 ## Author: Alumian
 ## Notes: Classic EPGP handles your guild's EPGP and master loot distribution. Usage: /CEPGP or /cep for options
-## SavedVariables: CHANNEL, CEPGP_lootChannel, COEF, MOD_COEF, MOD, AUTOEP, EPVALS, BASEGP, STANDBYEP, STANDBYOFFLINE, STANDBYPERCENT, STANDBYRANKS, SLOTWEIGHTS, RECORDS, OVERRIDE_INDEX, TRAFFIC, CEPGP_raid_logs, CEPGP_standby_accept_whispers, CEPGP_standby_byrank, CEPGP_standby_manual, CEPGP_standby_whisper_msg, CEPGP_notice, CEPGP_keyword, ALLOW_FORCED_SYNC, CEPGP_force_sync_rank, CEPGP_loot_GUI, CEPGP_auto_pass, CEPGP_raid_wide_dist, CEPGP_standby_share, CEPGP_1120_notice, CEPGP_min_threshold, CEPPG_gp_tooltips, CEPGP_standbyRoster, CEPGP_suppress_announcements, CEPGP_minEP, CEPGP_minGPDecayFactor
+## SavedVariables: CHANNEL, CEPGP_lootChannel, COEF, MOD_COEF, MOD, AUTOEP, EPVALS, BASEGP, STANDBYEP, STANDBYOFFLINE, STANDBYPERCENT, STANDBYRANKS, SLOTWEIGHTS, RECORDS, OVERRIDE_INDEX, TRAFFIC, CEPGP_raid_logs, CEPGP_standby_accept_whispers, CEPGP_standby_byrank, CEPGP_standby_manual, CEPGP_standby_whisper_msg, CEPGP_notice, CEPGP_keyword, ALLOW_FORCED_SYNC, CEPGP_force_sync_rank, CEPGP_loot_GUI, CEPGP_auto_pass, CEPGP_raid_wide_dist, CEPGP_standby_share, CEPGP_1120_notice, CEPGP_min_threshold, CEPPG_gp_tooltips, CEPGP_standbyRoster, CEPGP_suppress_announcements, CEPGP_minEP, CEPGP_minGPDecayFactor, CEPGP_verbose_traffic_logging
 
 Locale\Locale.xml
 Tokens.lua

--- a/Core.lua
+++ b/Core.lua
@@ -80,6 +80,7 @@ TRAFFIC = {};
 CEPGP_raid_logs = {};
 CEPGP_standbyRoster = {};
 CEPGP_minEP = {false, 0};
+CEPGP_verbose_traffic_logging = false;
 
 local L = CEPGP_Locale:GetLocale("CEPGP")
 

--- a/Core.lua
+++ b/Core.lua
@@ -86,12 +86,12 @@ local L = CEPGP_Locale:GetLocale("CEPGP")
 
 --[[ EVENT AND COMMAND HANDLER ]]--
 function CEPGP_OnEvent(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-	
+
 	if event == "ADDON_LOADED" and arg1 == "CEPGP" then --arg1 = addon name
 		CEPGP_initialise();
 	elseif event == "GUILD_ROSTER_UPDATE" or event == "GROUP_ROSTER_UPDATE" then
 		CEPGP_rosterUpdate(event);
-		
+
 	elseif event == "PARTY_LOOT_METHOD_CHANGED" then
 		if GetLootMethod() == "master" and IsInRaid("player") and CEPGP_isML() == 0 then
 			_G["CEPGP_confirmation"]:Show();
@@ -123,20 +123,20 @@ function CEPGP_OnEvent(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ar
 				return;
 			end
 		end
-		
-	
+
+
 	elseif event == "CHAT_MSG_WHISPER" and string.lower(arg1) == string.lower(CEPGP_standby_whisper_msg) and CEPGP_standby_manual and CEPGP_standby_accept_whispers then
 		if not CEPGP_tContains(CEPGP_standbyRoster, arg5)
 		and not CEPGP_tContains(CEPGP_raidRoster, arg5, true)
 		and CEPGP_tContains(CEPGP_roster, arg5, true) then
 			CEPGP_addToStandby(arg5);
 		end
-			
+
 	elseif (event == "CHAT_MSG_WHISPER" and string.lower(arg1) == string.lower(CEPGP_keyword) and CEPGP_distributing) or
 		(event == "CHAT_MSG_WHISPER" and string.lower(arg1) == "!info") or
 		(event == "CHAT_MSG_WHISPER" and (string.lower(arg1) == "!infoguild" or string.lower(arg1) == "!inforaid" or string.lower(arg1) == "!infoclass")) then
 			CEPGP_handleComms(event, arg1, arg5);
-	
+
 	elseif (event == "CHAT_MSG_ADDON") then
 		if (arg1 == "CEPGP")then
 			if string.find(arg4, "-") then
@@ -144,8 +144,8 @@ function CEPGP_OnEvent(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ar
 			end
 			CEPGP_IncAddonMsg(arg2, arg4);
 		end
-	
-	elseif CEPGP_use then --EPGP and loot distribution related 
+
+	elseif CEPGP_use then --EPGP and loot distribution related
 		if event == "COMBAT_LOG_EVENT_UNFILTERED" then
 			local _, action, _, _, _, _, _, guid, name = CombatLogGetCurrentEventInfo();
 			if action == "UNIT_DIED" and string.find(guid, "Creature") then
@@ -166,7 +166,7 @@ function CEPGP_OnEvent(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ar
 					CEPGP_kills = CEPGP_kills + 1;
 				end
 			end
-			
+
 		elseif event == "CHAT_MSG_MONSTER_EMOTE" then
 			if arg1 == L["%s is resurrected by a nearby ally!"] then
 				if arg2 == L["Zealot Lor'Khan"] then
@@ -177,17 +177,17 @@ function CEPGP_OnEvent(event, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, ar
 					CEPGP_THEKAL_PARAMS["THEKAL_DEAD"] = false;
 				end
 			end
-			
+
 		elseif event == "CHAT_MSG_MONSTER_YELL" then
 			if arg2 == L["The Prophet Skeram"] then
 				if arg1 == L["You only delay... the inevetable."] then
 					CEPGP_handleCombat(arg2, true);
 				end
 			end
-			
+
 		elseif (event == "LOOT_OPENED" or event == "LOOT_CLOSED" or event == "LOOT_SLOT_CLEARED") then
 			CEPGP_handleLoot(event, arg1, arg2);
-		
+
 		elseif event == "PLAYER_REGEN_DISABLED" then -- Player has started combat
 			if CEPGP_debugMode then
 				CEPGP_print("Combat started");
@@ -204,13 +204,13 @@ function SlashCmdList.CEPGP(msg, editbox)
 		CEPGP_print("Classic EPGP Usage");
 		CEPGP_print("|cFF80FF80show|r - |cFFFF8080Manually shows the CEPGP window|r");
 		CEPGP_print("|cFF80FF80version|r - |cFFFF8080Checks the version of the addon everyone in your raid is running|r");
-		
+
 	elseif msg == "show" then
 		CEPGP_populateFrame();
 		ShowUIPanel(CEPGP_frame);
 		CEPGP_toggleFrame("");
 		CEPGP_updateGuild();
-	
+
 	elseif msg == "version" then
 		CEPGP_vInfo = {};
 		CEPGP_vSearch = "GUILD";
@@ -240,10 +240,10 @@ function SlashCmdList.CEPGP(msg, editbox)
 		CEPGP_groupVersion = CEPGP_tSort(CEPGP_groupVersion, 1);
 		ShowUIPanel(CEPGP_version);
 		CEPGP_UpdateVersionScrollBar();
-	
+
 	elseif strfind(msg, "currentchannel") then
 		CEPGP_print("Current channel to report: " .. getCurChannel());
-		
+
 	elseif strfind(msg, "debugmode") then
 		CEPGP_debugMode = not CEPGP_debugMode;
 		if CEPGP_debugMode then
@@ -251,10 +251,10 @@ function SlashCmdList.CEPGP(msg, editbox)
 		else
 			CEPGP_print("Debug Mode Disabled");
 		end
-		
+
 	elseif strfind(msg, "debug") then
 		CEPGP_debuginfo:Show();
-	
+
 	else
 		CEPGP_print("|cFF80FF80" .. msg .. "|r |cFFFF8080is not a valid request. Type /CEPGP to check addon usage|r", true);
 	end
@@ -282,7 +282,7 @@ function CEPGP_RaidAssistLootDist(link, gp, raidwide) --raidwide refers to wheth
 		if not name and CEPGP_itemExists(CEPGP_DistID) then
 			local item = Item:CreateFromItemID(tonumber(CEPGP_DistID));
 			item:ContinueOnItemLoad(function()
-				name, iString, _, _, _, _, _, _, slot, tex = GetItemInfo(CEPGP_DistID);	
+				name, iString, _, _, _, _, _, _, slot, tex = GetItemInfo(CEPGP_DistID);
 				CEPGP_responses = {};
 				_G["CEPGP_distribute_item_name"]:SetText(link);
 				if iString then
@@ -297,7 +297,7 @@ function CEPGP_RaidAssistLootDist(link, gp, raidwide) --raidwide refers to wheth
 					_G["CEPGP_distribute_item_texture"]:SetTexture(nil);
 				end
 				_G["CEPGP_distribute_item_tex"]:SetScript('OnLeave', function() GameTooltip:Hide() end);
-				_G["CEPGP_distribute_GP_value"]:SetText(gp);				
+				_G["CEPGP_distribute_GP_value"]:SetText(gp);
 			end);
 		else
 			CEPGP_responses = {};
@@ -324,6 +324,7 @@ end
 function CEPGP_AddRaidEP(amount, msg, encounter)
 	amount = math.floor(amount);
 	local total = GetNumGroupMembers();
+	local raid_timestamp = time();
 	if total > 0 then
 		for i = 1, total do
 			local name = GetRaidRosterInfo(i);
@@ -349,16 +350,16 @@ function CEPGP_AddRaidEP(amount, msg, encounter)
 	end
 	if msg ~= "" and msg ~= nil or encounter then
 		if encounter then -- a boss was killed
-			TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Add Raid EP +" .. amount .. " - " .. encounter, "", "", "", "", "", time()};
+			TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Add Raid EP +" .. amount .. " - " .. encounter, "", "", "", "", "", raid_timestamp};
 			CEPGP_ShareTraffic("Raid", UnitName("player"), "Add Raid EP +" .. amount .. " - " .. encounter);
 			CEPGP_sendChatMessage(msg, CHANNEL);
 		else -- EP was manually given, could be either positive or negative, and a message was written
 			if tonumber(amount) <= 0 then
-				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Subtract Raid EP +" .. amount .. " (" .. msg .. ")", "", "", "", "", "", time()};
+				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Subtract Raid EP +" .. amount .. " (" .. msg .. ")", "", "", "", "", "", raid_timestamp};
 				CEPGP_ShareTraffic("Raid", UnitName("player"), "Subtract Raid EP " .. amount .. " (" .. msg .. ")");
 				CEPGP_sendChatMessage(amount .. " EP taken from all raid members (" .. msg .. ")", CHANNEL);
 			else
-				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Add Raid EP +" .. amount .. " (" .. msg .. ")", "", "", "", "", "", time()};
+				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Add Raid EP +" .. amount .. " (" .. msg .. ")", "", "", "", "", "", raid_timestamp};
 				CEPGP_ShareTraffic("Raid", UnitName("player"), "Add Raid EP +" .. amount .. " (" .. msg .. ")");
 				CEPGP_sendChatMessage(amount .. " EP awarded to all raid members (" .. msg .. ")", CHANNEL);
 			end
@@ -366,11 +367,11 @@ function CEPGP_AddRaidEP(amount, msg, encounter)
 	else -- no message was written
 		if tonumber(amount) <= 0 then
 			amount = string.sub(amount, 2, string.len(amount));
-			TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Subtract Raid EP -" .. amount, "", "", "", "", "", time()};
-			CEPGP_ShareTraffic("Raid", UnitName("player"), "Subtract Raid EP -" .. amount);	
+			TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Subtract Raid EP -" .. amount, "", "", "", "", "", raid_timestamp};
+			CEPGP_ShareTraffic("Raid", UnitName("player"), "Subtract Raid EP -" .. amount);
 			CEPGP_sendChatMessage(amount .. " EP taken from all raid members", CHANNEL);
 		else
-			TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Add Raid EP +" .. amount, "", "", "", "", "", time()};
+			TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Raid", UnitName("player"), "Add Raid EP +" .. amount, "", "", "", "", "", raid_timestamp};
 			CEPGP_ShareTraffic("Raid", UnitName("player"), "Add Raid EP +" .. amount);
 			CEPGP_sendChatMessage(amount .. " EP awarded to all raid members", CHANNEL);
 		end
@@ -465,7 +466,7 @@ function CEPGP_addStandbyEP(amount, boss, msg)
 				end
 				if EP < 0 then
 					EP = 0;
-				end				
+				end
 				for i = 1, table.getn(STANDBYRANKS) do
 					if STANDBYRANKS[i][1] == rank then
 						if STANDBYRANKS[i][2] == true and (online or STANDBYOFFLINE) then
@@ -682,7 +683,7 @@ function CEPGP_addGP(player, amount, itemID, itemLink, msg)
 				else
 					CEPGP_ShareTraffic(player, UnitName("player"), "Add GP " .. amount, EP, EP, GPB, GP);
 				end
-				
+
 			end
 		end
 		CEPGP_UpdateTrafficScrollBar();
@@ -822,21 +823,21 @@ function CEPGP_decay(amount, msg)
 			amount = string.sub(amount, 2, string.len(amount));
 			if msg ~= "" and msg ~= nil then
 				CEPGP_sendChatMessage("Guild EPGP inflated by " .. amount .. "% (" .. msg .. ")", CHANNEL);
-				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Guild", UnitName("player"), "Inflated EPGP +" .. amount .. "% (" .. msg .. ")", "", "", "", "", "", time()}; 
+				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Guild", UnitName("player"), "Inflated EPGP +" .. amount .. "% (" .. msg .. ")", "", "", "", "", "", time()};
 				CEPGP_ShareTraffic("Guild", UnitName("player"), "Inflated EPGP +" .. amount .. "% (" .. msg .. ")");
 			else
 				CEPGP_sendChatMessage("Guild EPGP inflated by " .. amount .. "%", CHANNEL);
-				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Guild", UnitName("player"), "Inflated EPGP +" .. amount .. "%", "", "", "", "", "", time()}; 
+				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Guild", UnitName("player"), "Inflated EPGP +" .. amount .. "%", "", "", "", "", "", time()};
 				CEPGP_ShareTraffic("Guild", UnitName("player"), "Inflated EPGP +" .. amount .. "%");
 			end
 		else
 			if msg ~= "" and msg ~= nil then
 				CEPGP_sendChatMessage("Guild EPGP decayed by " .. amount .. "% (" .. msg .. ")", CHANNEL);
-				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Guild", UnitName("player"), "Decay EPGP -" .. amount .. "% (" .. msg .. ")", "", "", "", "", "", time()}; 
+				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Guild", UnitName("player"), "Decay EPGP -" .. amount .. "% (" .. msg .. ")", "", "", "", "", "", time()};
 				CEPGP_ShareTraffic("Guild", UnitName("player"), "Decayed EPGP -" .. amount .. "% (" .. msg .. ")");
 			else
 				CEPGP_sendChatMessage("Guild EPGP decayed by " .. amount .. "%", CHANNEL);
-				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Guild", UnitName("player"), "Decay EPGP -" .. amount .. "%", "", "", "", "", "", time()}; 
+				TRAFFIC[CEPGP_ntgetn(TRAFFIC)+1] = {"Guild", UnitName("player"), "Decay EPGP -" .. amount .. "%", "", "", "", "", "", time()};
 				CEPGP_ShareTraffic("Guild", UnitName("player"), "Decayed EPGP -" .. amount .. "%");
 			end
 		end

--- a/Core.lua
+++ b/Core.lua
@@ -330,12 +330,12 @@ function CEPGP_AddRaidEP(amount, msg, encounter)
   local log_message = "";
 
 	-- Parse the message and entounter field to determine what message is saved to logs
-	if tonumber(amount) <= 0 then
+	if amount <= 0 then
 		log_message = "Subract";
 	else
 		log_message = "Add";
 	end
-	log_message = log_message .. " " .. amount .. " Raid EP";
+	log_message = log_message .. " " .. math.abs(amount) .. " Raid EP";
 	if encounter then
 		log_message = log_message .. " - " .. encounter;
 	elseif msg ~= "" and msg ~= nil then
@@ -380,8 +380,12 @@ function CEPGP_AddRaidEP(amount, msg, encounter)
 		CEPGP_ShareTraffic("Raid", UnitName("player"), log_message);
 	end
 
-	-- Send a message to the raid
-	CEPGP_sendChatMessage(log_message, CHANNEL);
+	-- Send a message to the raid.  If it's an encounter, send the "msg" parameter instead of the log_message
+	if encounter then
+		CEPGP_sendChatMessage(msg, CHANNEL);
+	else
+		CEPGP_sendChatMessage(log_message, CHANNEL);
+	end
 
 	CEPGP_UpdateTrafficScrollBar();
 end

--- a/Core.lua
+++ b/Core.lua
@@ -323,6 +323,7 @@ end
 --[[ ADD EPGP FUNCTIONS ]]--
 
 function CEPGP_AddRaidEP(amount, msg, encounter)
+	-- Returns true when successful, else false
 	amount = math.floor(amount);
 	local total = GetNumGroupMembers();
 
@@ -330,7 +331,10 @@ function CEPGP_AddRaidEP(amount, msg, encounter)
   local log_message = "";
 
 	-- Parse the message and entounter field to determine what message is saved to logs
-	if amount <= 0 then
+  if amount == 0 then
+		CEPGP_print("Cannot add 0 EP");
+		return false;
+	elseif amount < 0 then
 		log_message = "Subract";
 	else
 		log_message = "Add";
@@ -388,6 +392,7 @@ function CEPGP_AddRaidEP(amount, msg, encounter)
 	end
 
 	CEPGP_UpdateTrafficScrollBar();
+	return true;
 end
 
 function CEPGP_addGuildEP(amount, msg)

--- a/Frame.xml
+++ b/Frame.xml
@@ -3,7 +3,7 @@
 	<Script File="Button.lua"/>
 	<Script File="Utility.lua"/>
 	<Script File="Core.lua"/>
-		
+
 	<Frame name="CEPGP_frame" parent="UIParent" hidden="true" enableMouse="true" toplevel="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="450" y="480" />
@@ -150,7 +150,7 @@
 					</OnClick>
 				</Scripts>
 			</Button>
-			<Frame name="CEPGP_guild" inherits="CEPGPFrameTemplate">				
+			<Frame name="CEPGP_guild" inherits="CEPGPFrameTemplate">
 				<Frames>
 					<Button name="CEPGP_button_guild_dump" inherits="GameMenuButtonTemplate" text="Save Standings">
 						<Size>
@@ -342,7 +342,7 @@
 						<Scripts>
 							<OnClick>
 								CEPGP_setCriteria(6, "Guild");
-							</OnClick>							
+							</OnClick>
 						</Scripts>
 					</Button>
 					<Button name="CEPGP_guild_PR" inherits="CEPGPHeaderButton" text="PR">
@@ -1942,7 +1942,7 @@
 										self:SetChecked(CEPGP_standby_byrank);
 										if self:GetChecked() then
 											CEPGP_toggleStandbyRanks(true);
-											
+
 										else
 											CEPGP_toggleStandbyRanks(false);
 										end
@@ -2163,6 +2163,14 @@
 								</Anchor>
 							</Anchors>
 						</FontString>
+						<FontString name="CEPGP_verbose_traffic_logging_text" inherits="GameFontNormal" text="Verbose EPGP Traffic Logging: ">
+							<Color r="1" g="1" b="1" />
+							<Anchors>
+								<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeTo="CEPGP_options_min_EP_text">
+									<AbsDimension x="0" y="-7" />
+								</Anchor>
+							</Anchors>
+						</FontString>
 						<FontString name="CEPGP_options_force_sync" inherits="GameFontNormal" text="Allow Forced Synchronisation from Rank:">
 							<Color r="1" g="1" b="1"/>
 							<Anchors>
@@ -2309,6 +2317,43 @@
 							</OnShow>
 						</Scripts>
 					</EditBox>
+					<CheckButton name="CEPGP_verbose_traffic_logging_check" inherits="UIOptionsCheckButtonTemplate">
+						<HitRectInsets>
+							<AbsInset left="0" right="0" top="0" bottom="0" />
+						</HitRectInsets>
+						<Anchors>
+							<Anchor point="LEFT" relativePoint="RIGHT" relativeTo="CEPGP_verbose_traffic_logging_text">
+								<Offset>
+									<AbsDimension x="-5" y="0" />
+								</Offset>
+							</Anchor>
+						</Anchors>
+						<Scripts>
+							<OnClick>
+								if self:GetChecked() then
+									CEPGP_verbose_traffic_logging = true;
+									CEPGP_print("Now logging verbose EPGP traffic.");
+								else
+									CEPGP_verbose_traffic_logging = false;
+									CEPGP_print("No longer logging verbose EPGP traffic.");
+								end
+							</OnClick>
+							<OnEnter>
+								GameTooltip:SetOwner(self, "ANCHOR_TOPRIGHT");
+								GameTooltip:SetText("Loot Master Feature\nLog EPGP traffic for each individual user, instead of collectively for the raid");
+							</OnEnter>
+							<OnLeave>
+								GameTooltip:Hide();
+							</OnLeave>
+							<OnShow>
+								if CEPGP_verbose_traffic_logging then
+									self:SetChecked(true);
+								else
+									self:SetChecked(false);
+								end
+							</OnShow>
+						</Scripts>
+					</CheckButton>
 					<Button name="CEPGP_sync_rank" inherits="UIDropDownMenuTemplate">
 						<Anchors>
 							<Anchor point="LEFT" relativePoint="RIGHT" relativeTo="CEPGP_options_allow_forced_sync_check">
@@ -2635,7 +2680,7 @@
 						</Anchors>
 						<Scripts>
 							<OnClick>
-								PlaySound(799);								
+								PlaySound(799);
 								CEPGP_toggleBossConfigFrame("CEPGP_options_page_3_mc");
 							</OnClick>
 						</Scripts>
@@ -2653,7 +2698,7 @@
 						</Anchors>
 						<Scripts>
 							<OnClick>
-								PlaySound(799);								
+								PlaySound(799);
 								CEPGP_toggleBossConfigFrame("CEPGP_options_page_3_bwl");
 							</OnClick>
 						</Scripts>
@@ -2671,7 +2716,7 @@
 						</Anchors>
 						<Scripts>
 							<OnClick>
-								PlaySound(799);								
+								PlaySound(799);
 								CEPGP_toggleBossConfigFrame("CEPGP_options_page_3_zg");
 							</OnClick>
 						</Scripts>
@@ -2689,7 +2734,7 @@
 						</Anchors>
 						<Scripts>
 							<OnClick>
-								PlaySound(799);								
+								PlaySound(799);
 								CEPGP_toggleBossConfigFrame("CEPGP_options_page_3_aq20");
 							</OnClick>
 						</Scripts>
@@ -2707,7 +2752,7 @@
 						</Anchors>
 						<Scripts>
 							<OnClick>
-								PlaySound(799);								
+								PlaySound(799);
 								CEPGP_toggleBossConfigFrame("CEPGP_options_page_3_aq40");
 							</OnClick>
 						</Scripts>
@@ -2725,7 +2770,7 @@
 						</Anchors>
 						<Scripts>
 							<OnClick>
-								PlaySound(799);								
+								PlaySound(799);
 								CEPGP_toggleBossConfigFrame("CEPGP_options_page_3_naxx");
 							</OnClick>
 						</Scripts>
@@ -2743,7 +2788,7 @@
 						</Anchors>
 						<Scripts>
 							<OnClick>
-								PlaySound(799);								
+								PlaySound(799);
 								CEPGP_toggleBossConfigFrame("CEPGP_options_page_3_worldboss");
 							</OnClick>
 						</Scripts>
@@ -2885,7 +2930,7 @@
 							<CheckButton name="CEPGP_options_Majordomo Executus_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Ragnaros_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Onyxia_auto_check" inherits="AutoAwardEPCheckBox" />
-							
+
 							<EditBox name="CEPGP_options_Lucifron_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Magmadar_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Gehennas_EP_value" inherits="epValInputBoxTemplate" />
@@ -3003,7 +3048,7 @@
 							<CheckButton name="CEPGP_options_Flamegor_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Chromaggus_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Nefarian_auto_check" inherits="AutoAwardEPCheckBox" />
-							
+
 							<EditBox name="CEPGP_options_Razorgore the Untamed_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Vaelastrasz the Corrupt_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Broodlord Lashlayer_EP_value" inherits="epValInputBoxTemplate" />
@@ -3140,7 +3185,7 @@
 							<CheckButton name="CEPGP_options_Jin'do the Hexxer_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Gahz'ranka_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Hakkar_auto_check" inherits="AutoAwardEPCheckBox" />
-							
+
 							<EditBox name="CEPGP_options_High Priest Venoxis_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_High Priestess Jeklik_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_High Priestess Mar'li_EP_value" inherits="epValInputBoxTemplate" />
@@ -3235,7 +3280,7 @@
 							<CheckButton name="CEPGP_options_Buru the Gorger_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Ayamiss the Hunter_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Ossirian the Unscarred_auto_check" inherits="AutoAwardEPCheckBox" />
-							
+
 							<EditBox name="CEPGP_options_Kurinnaxx_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_General Rajaxx_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Moam_EP_value" inherits="epValInputBoxTemplate" />
@@ -3359,7 +3404,7 @@
 							<CheckButton name="CEPGP_options_Ouro_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_The Twin Emperors_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_C'Thun_auto_check" inherits="AutoAwardEPCheckBox" />
-							
+
 							<EditBox name="CEPGP_options_The Prophet Skeram_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Battleguard Sartura_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Fankriss the Unyielding_EP_value" inherits="epValInputBoxTemplate" />
@@ -3552,7 +3597,7 @@
 							<CheckButton name="CEPGP_options_Thaddius_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Sapphiron_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Kel'Thuzad_auto_check" inherits="AutoAwardEPCheckBox" />
-							
+
 							<EditBox name="CEPGP_options_Anub'Rekhan_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Grand Widow Faerlina_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Maexxna_EP_value" inherits="epValInputBoxTemplate" />
@@ -3663,7 +3708,7 @@
 							<CheckButton name="CEPGP_options_Lethon_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Ysondre_auto_check" inherits="AutoAwardEPCheckBox" />
 							<CheckButton name="CEPGP_options_Taerar_auto_check" inherits="AutoAwardEPCheckBox" />
-							
+
 							<EditBox name="CEPGP_options_Doom Lord Kazzak_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Azuregos_EP_value" inherits="epValInputBoxTemplate" />
 							<EditBox name="CEPGP_options_Teremus the Devourer_EP_value" inherits="epValInputBoxTemplate" />
@@ -3944,7 +3989,7 @@
 							</OnClick>
 						</Scripts>
 					</Button>
-					
+
 				</Frames>
 				<Layers>
 					<Layer level="OVERLAY">
@@ -3987,7 +4032,7 @@
 			</OnEvent>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_version" enableMouse="true" toplevel="true" hidden="true" movable="true" parent="UIParent" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="450" y="450" />
@@ -4207,7 +4252,7 @@
 			</OnDragStop>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_distribute_popup" toplevel="true" frameStrata="DIALOG" enableMouse="true" parent="UIParent" hidden="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="300" y="100"/>
@@ -4341,7 +4386,7 @@
 			</OnHide>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_context_popup" toplevel="true" frameStrata="DIALOG" enableMouse="true" parent="UIParent" hidden="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="300" y="175"/>
@@ -4561,7 +4606,7 @@
 			</OnDragStop>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_save_guild_logs" toplevel="true" frameStrata="DIALOG" enableMouse="true" parent="UIParent" hidden="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="300" y="175"/>
@@ -4711,7 +4756,7 @@
 			</OnDragStop>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_restore_guild_logs" toplevel="true" frameStrata="DIALOG" enableMouse="true" parent="UIParent" hidden="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="300" y="175"/>
@@ -4883,7 +4928,7 @@
 			</OnHide>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_settings_import" toplevel="true" frameStrata="DIALOG" enableMouse="true" parent="UIParent" hidden="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="300" y="175"/>
@@ -5016,7 +5061,7 @@
 			</OnDragStop>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_override" toplevel="true" frameStrata="DIALOG" enableMouse="true" parent="UIParent" hidden="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="450" y="480"/>
@@ -5383,7 +5428,7 @@
 						</Anchors>
 						<Scripts>
 							<OnVerticalScroll>
-								FauxScrollFrame_OnVerticalScroll(self, offset, 15, CEPGP_UpdateOverrideScrollBar); 
+								FauxScrollFrame_OnVerticalScroll(self, offset, 15, CEPGP_UpdateOverrideScrollBar);
 							</OnVerticalScroll>
 							<OnShow>
 								CEPGP_UpdateOverrideScrollBar();
@@ -5573,7 +5618,7 @@
 			</OnDragStop>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_traffic" toplevel="true" frameStrata="HIGH" enableMouse="true" parent="UIParent" hidden="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="800" y="480"/>
@@ -5872,7 +5917,7 @@
 			</ScrollFrame>
 		</Frames>
 	</Frame>
-	
+
 	<Frame name="CEPGP_notice_frame" parent="UIParent" hidden="true" enableMouse="true" toplevel="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="0" y="350" />
@@ -5981,7 +6026,7 @@
 			</OnMouseUp>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_attendance" parent="UIParent" hidden="true" enableMouse="true" toplevel="true" movable="true" clampedToScreen="true">
 		<size>
 			<AbsDimension x="650" y="425" />
@@ -6868,7 +6913,7 @@
 			</OnLoad>
 		</Scripts>
 	</Frame>
-	
+
 	<Frame name="CEPGP_update_notice" parent="UIParent" hidden="true" enableMouse="true" toplevel="true" movable="true" clampedToScreen="true">
 		<Size>
 			<AbsDimension x="300" y="150" />

--- a/Utility.lua
+++ b/Utility.lua
@@ -98,28 +98,28 @@ function CEPGP_initialise()
 	tinsert(UISpecialFrames, "CEPGP_settings_import");
 	tinsert(UISpecialFrames, "CEPGP_override");
 	tinsert(UISpecialFrames, "CEPGP_traffic");
-	
+
 	C_ChatInfo.RegisterAddonMessagePrefix("CEPGP"); --Registers CEPGP for use in the addon comms environment
 	CEPGP_SendAddonMsg("version-check", "GUILD");
 	DEFAULT_CHAT_FRAME:AddMessage("|c00FFC100Classic EPGP Version: " .. CEPGP_VERSION .. " Loaded|r");
 	DEFAULT_CHAT_FRAME:AddMessage("|c00FFC100CEPGP: Currently reporting to channel - " .. CHANNEL .. "|r");
-	
+
 	if not CEPGP_notice then
 		CEPGP_notice_frame:Show();
 	elseif not CEPGP_1120_notice then
 		_G["CEPGP_update_notice"]:Show();
 	end
-	
+
 	if IsInRaid("player") and CEPGP_isML() == 0 then
 		_G["CEPGP_confirmation"]:Show();
 	end
-	
+
 	CEPGP_updateGuild();
 	GameTooltip:HookScript("OnTooltipSetItem", CEPGP_addGPTooltip);
 	hooksecurefunc("ChatFrame_OnHyperlinkShow", CEPGP_addGPHyperlink);
 end
 
-function CEPGP_calcGP(link, quantity, id)	
+function CEPGP_calcGP(link, quantity, id)
 	local name, rarity, ilvl, itemType, subType, slot, classID, subClassID;
 	if id then
 		name, link, rarity, ilvl, itemType, subType, _, _, slot, _, _, classID, subClassID = GetItemInfo(id);
@@ -142,7 +142,7 @@ function CEPGP_calcGP(link, quantity, id)
 					return v;
 				end
 			end
-			
+
 			for _, k in pairs(CEPGP_tokens) do
 			for slotName, v in pairs(k) do
 				if k[slotName][tonumber(id)] then
@@ -155,7 +155,7 @@ function CEPGP_calcGP(link, quantity, id)
 		if slot == "" or slot == nil then
 			slot = "INVTYPE_EXCEPTION";
 		end
-			
+
 			if slot == "INVTYPE_ROBE" then slot = "INVTYPE_CHEST"; end
 			if slot == "INVTYPE_WEAPON" then slot = "INVTYPE_WEAPONOFFHAND"; end
 			if CEPGP_debugMode then
@@ -202,7 +202,7 @@ function CEPGP_calcGP(link, quantity, id)
 		if slot == "" or slot == nil then
 			slot = "INVTYPE_EXCEPTION";
 		end
-		
+
 		if slot == "INVTYPE_ROBE" then slot = "INVTYPE_CHEST"; end
 		if slot == "INVTYPE_WEAPON" then slot = "INVTYPE_WEAPONOFFHAND"; end
 		if CEPGP_debugMode then
@@ -237,13 +237,13 @@ function CEPGP_addGPTooltip(self)
 		local item = Item:CreateFromItemID(tonumber(id));
 		item:ContinueOnItemLoad(function()
 			local gp = CEPGP_calcGP(_, 1, id);
-			GameTooltip:AddLine("GP Value: " .. gp, {1,1,1});	
+			GameTooltip:AddLine("GP Value: " .. gp, {1,1,1});
 		end);
 	else
 		local gp = CEPGP_calcGP(_, 1, id);
 		GameTooltip:AddLine("GP Value: " .. gp, {1,1,1});
 	end
-	
+
 end
 
 function CEPGP_addGPHyperlink(self, iString)
@@ -292,7 +292,7 @@ function CEPGP_populateFrame(CEPGP_criteria, items)
 			total = 0;
 		else
 			local i = 1;
-			for _,value in pairs(items) do 
+			for _,value in pairs(items) do
 				tempItems[i] = value;
 				i = i + 1;
 				count = count + 1;
@@ -301,7 +301,7 @@ function CEPGP_populateFrame(CEPGP_criteria, items)
 		end
 		total = count;
 	end
-	if CEPGP_mode == "loot" then 
+	if CEPGP_mode == "loot" then
 		for i = 1, total do
 			local texture, name, quality, gp, colour, iString, link, slot, x, quantity;
 			x = i;
@@ -318,21 +318,21 @@ function CEPGP_populateFrame(CEPGP_criteria, items)
 				_G[CEPGP_mode..'announce'..i]:SetWidth(20);
 				_G[CEPGP_mode..'announce'..i]:SetScript('OnClick', function() CEPGP_announce(link, x, slot, quantity) CEPGP_distribute:SetID(_G[CEPGP_mode..'announce'..i]:GetID()) end);
 				_G[CEPGP_mode..'announce'..i]:SetID(slot);
-				
+
 				_G[CEPGP_mode..'icon'..i]:Show();
 				_G[CEPGP_mode..'icon'..i]:SetScript('OnEnter', function() GameTooltip:SetOwner(_G[CEPGP_mode..'icon'..i], "ANCHOR_BOTTOMLEFT") GameTooltip:SetHyperlink(iString) GameTooltip:Show() end);
 				_G[CEPGP_mode..'icon'..i]:SetScript('OnLeave', function() GameTooltip:Hide() end);
-				
+
 				_G[CEPGP_mode..'texture'..i]:Show();
 				_G[CEPGP_mode..'texture'..i]:SetTexture(texture);
-				
+
 				_G[CEPGP_mode..'item'..i]:Show();
 				_G[CEPGP_mode..'item'..i].text:SetText(link);
 				_G[CEPGP_mode..'item'..i].text:SetTextColor(colour.r, colour.g, colour.b);
 				_G[CEPGP_mode..'item'..i].text:SetPoint('CENTER',_G[CEPGP_mode..'item'..i]);
 				_G[CEPGP_mode..'item'..i]:SetWidth(_G[CEPGP_mode..'item'..i].text:GetStringWidth());
 				_G[CEPGP_mode..'item'..i]:SetScript('OnClick', function() SetItemRef(link, iString) end);
-				
+
 				_G[CEPGP_mode..'itemGP'..i]:SetText(gp);
 				_G[CEPGP_mode..'itemGP'..i]:SetTextColor(colour.r, colour.g, colour.b);
 				_G[CEPGP_mode..'itemGP'..i]:SetWidth(35);
@@ -345,24 +345,24 @@ function CEPGP_populateFrame(CEPGP_criteria, items)
 				subframe.announce:SetWidth(20);
 				subframe.announce:SetScript('OnClick', function() CEPGP_announce(link, x, slot, quantity) CEPGP_distribute:SetID(_G[CEPGP_mode..'announce'..i]:GetID()); end);
 				subframe.announce:SetID(slot);
-	
+
 				subframe.icon = CreateFrame('Button', CEPGP_mode..'icon'..i, subframe);
 				subframe.icon:SetHeight(20);
 				subframe.icon:SetWidth(20);
 				subframe.icon:SetScript('OnEnter', function() GameTooltip:SetOwner(_G[CEPGP_mode..'icon'..i], "ANCHOR_BOTTOMLEFT") GameTooltip:SetHyperlink(link) GameTooltip:Show() end);
 				subframe.icon:SetScript('OnLeave', function() GameTooltip:Hide() end);
-				
+
 				local tex = subframe.icon:CreateTexture(CEPGP_mode..'texture'..i, "BACKGROUND");
 				tex:SetAllPoints();
 				tex:SetTexture(texture);
-				
+
 				subframe.itemName = CreateFrame('Button', CEPGP_mode..'item'..i, subframe);
 				subframe.itemName:SetHeight(20);
-				
+
 				subframe.itemGP = CreateFrame('EditBox', CEPGP_mode..'itemGP'..i, subframe, 'InputBoxTemplate');
 				subframe.itemGP:SetHeight(20);
 				subframe.itemGP:SetWidth(35);
-				
+
 				if i == 1 then
 					subframe.announce:SetPoint('CENTER', _G['CEPGP_'..CEPGP_mode..'_announce'], 'BOTTOM', -10, -20);
 					subframe.icon:SetPoint('LEFT', _G[CEPGP_mode..'announce'..i], 'RIGHT', 10, 0);
@@ -376,16 +376,16 @@ function CEPGP_populateFrame(CEPGP_criteria, items)
 					subframe.itemName:SetPoint('LEFT', _G[CEPGP_mode..'icon'..i], 'RIGHT', 10, 0);
 					subframe.itemGP:SetPoint('CENTER', _G[CEPGP_mode..'itemGP'..(i-1)], 'BOTTOM', 0, -20);
 				end
-				
+
 				subframe.icon:SetScript('OnClick', function() SetItemRef(link, iString) end);
-				
+
 				subframe.itemName.text = subframe.itemName:CreateFontString(CEPGP_mode..'EPGP_i'..name..'text', 'OVERLAY', 'GameFontNormal');
 				subframe.itemName.text:SetPoint('CENTER', _G[CEPGP_mode..'item'..i]);
 				subframe.itemName.text:SetText(link);
 				subframe.itemName.text:SetTextColor(colour.r, colour.g, colour.b);
 				subframe.itemName:SetWidth(subframe.itemName.text:GetStringWidth());
 				subframe.itemName:SetScript('OnClick', function() SetItemRef(link, iString) end);
-				
+
 				subframe.itemGP:SetText(gp);
 				subframe.itemGP:SetTextColor(colour.r, colour.g, colour.b);
 				subframe.itemGP:SetWidth(35);
@@ -418,8 +418,8 @@ function CEPGP_cleanTable()
 		_G[CEPGP_mode..'member_PR'..i].text:SetText("");
 		i = i + 1;
 	end
-	
-	
+
+
 	i = 1;
 	while _G[CEPGP_mode..'item'..i] ~= nil do
 		_G[CEPGP_mode..'announce'..i]:Hide();
@@ -504,7 +504,7 @@ function CEPGP_rosterUpdate(event)
 			CEPGP_standbyRoster = {};
 		end
 		CEPGP_UpdateStandbyScrollBar();
-		
+
 	elseif event == "GROUP_ROSTER_UPDATE" then
 		if IsInRaid("player") and CEPGP_isML() == 0 then
 			if not CEPGP_use then
@@ -567,7 +567,7 @@ function CEPGP_rosterUpdate(event)
 		else --[[ Hides the raid and loot distribution buttons if the player is not in a raid group ]]--
 			CEPGP_mode = "guild";
 			CEPGP_toggleFrame("CEPGP_guild");
-			
+
 		end
 		if _G["CEPGP_guild"]:IsVisible() then
 			CEPGP_UpdateRaidScrollBar();
@@ -600,7 +600,7 @@ function CEPGP_addToStandby(player)
 			CEPGP_print(player .. " is part of the raid", true);
 			return;
 		end
-	end	
+	end
 	local _, class, rank, rankIndex, oNote, _, classFile = CEPGP_getGuildInfo(player);
 	local EP,GP = CEPGP_getEPGP(oNote);
 	CEPGP_standbyRoster[#CEPGP_standbyRoster+1] = {
@@ -623,7 +623,7 @@ function CEPGP_standardiseString(str)
 	--Returns the string with proper nouns capitalised
 	if not str then return; end
 	local words = {};
-	
+
 	local count = 0;
 	for i in (str .. " "):gmatch("([^ ]*) ") do
 		if count == 0 then
@@ -652,7 +652,7 @@ function CEPGP_standardiseString(str)
 			result = result .. " " .. words[i];
 		end
 	end
-	
+
 	return result;
 end
 
@@ -788,7 +788,7 @@ function CEPGP_getEPGP(offNote, index, name)
 						CEPGP_print("An error was found with " .. name .. "'s GP. Their EPGP has been salvaged as " .. EP .. "," .. GP .. ". Please confirm if this is correct and modify the officer note if required.");
 					end
 					return EP,GP;
-					
+
 				elseif string.find(offNote, '[0-9]+$') then
 					EP = tonumber(strsub(offNote, 1, strfind(offNote, ",")-1));
 					GP = strsub(offNote, string.find(offNote, '[0-9]+$'), string.len(offNote));
@@ -797,7 +797,7 @@ function CEPGP_getEPGP(offNote, index, name)
 						CEPGP_print("An error was found with " .. name .. "'s GP. Their EPGP has been salvaged as " .. EP .. "," .. GP .. ". Please confirm if this is correct and modify the officer note if required.");
 					end
 					return EP,GP;
-					
+
 				else
 					EP = tonumber(strsub(offNote, 1, strfind(offNote, ",")-1));
 					if CanEditOfficerNote() then
@@ -806,11 +806,11 @@ function CEPGP_getEPGP(offNote, index, name)
 					end
 					return EP, BASEGP;
 				end
-				
+
 				return EP, BASEGP;
 			elseif string.find(offNote, ',[0-9]+$') then --GP is assumed in tact
 				GP = tonumber(strsub(offNote, strfind(offNote, ",")+1, string.len(offNote)));
-				
+
 				if string.find(offNote, '[^0-9]+,[0-9]+$') then --EP might still be intact, but characters might be padding between EP and the comma
 					EP = strsub(offNote, 1, string.find(offNote, '[^0-9]+,')-1);
 					if CanEditOfficerNote() then
@@ -818,7 +818,7 @@ function CEPGP_getEPGP(offNote, index, name)
 						CEPGP_print("An error was found with " .. name .. "'s EP. Their EPGP has been salvaged as " .. EP .. "," .. GP .. ". Please confirm if this is correct and modify the officer note if required.");
 					end
 					return EP, GP;
-					
+
 				elseif string.find(offNote, '^[^0-9]+[0-9]+,[0-9]+$') then --or pheraps the error is at the start of the string?
 					EP = strsub(offNote, string.find(offNote, '[0-9]+,'), string.find(offNote, ',[0-9]+$')-1);
 					if CanEditOfficerNote() then
@@ -826,7 +826,7 @@ function CEPGP_getEPGP(offNote, index, name)
 						CEPGP_print("An error was found with " .. name .. "'s EP. Their EPGP has been salvaged as " .. EP .. "," .. GP .. ". Please confirm if this is correct and modify the officer note if required.");
 					end
 					return EP, GP;
-					
+
 				else --EP cannot be salvaged
 					if CanEditOfficerNote() then
 						--GuildRosterSetOfficerNote(index, "0," .. GP);
@@ -841,7 +841,7 @@ function CEPGP_getEPGP(offNote, index, name)
 		end
 	end
 	local EP, GP = nil;
-	
+
 	if offNote == "" then --Click here to set an officer note qualifies as blank, also occurs if the officer notes are not visible
 		return 0, tonumber(BASEGP);
 	end
@@ -960,7 +960,7 @@ function CEPGP_tContains(t, val, bool)
 			end
 		end
 	elseif bool == true then
-		for index,_ in pairs(t) do 
+		for index,_ in pairs(t) do
 			if index == val then
 				return true;
 			end
@@ -1193,7 +1193,7 @@ function CEPGP_UIDropDownMenu_Initialize(frame, initFunction, displayMode, level
 		end
 	end
 	frame:SetHeight(UIDROPDOWNMENU_BUTTON_HEIGHT * 2);
-	
+
 	-- Set the initialize function and call it.  The initFunction populates the dropdown list.
 	if ( initFunction ) then
 		frame.initialize = initFunction;
@@ -1254,7 +1254,7 @@ function CEPGP_getDebugInfo()
 	else
 		info = info .. "Standby EP Manual Delegation: False<br />\n";
 	end
-	
+
 	if CEPGP_loot_GUI then
 		info = info .. "GUI for Loot: True<br />\n";
 	else
@@ -1426,8 +1426,8 @@ function CEPGP_formatExport()
 	end
 	temp = CEPGP_tSort(temp, 1);
 	local form = _G["CEPGP_export"]:GetAttribute("format");
-	
-	
+
+
 	if form == "CSV" then
 		for i = 1, #temp do
 			text = text .. temp[i][1];
@@ -1443,8 +1443,8 @@ function CEPGP_formatExport()
 		end
 		_G["CEPGP_export_dump"]:SetText(text);
 		_G["CEPGP_export_dump"]:HighlightText();
-		
-		
+
+
 	elseif form == "JSON" then
 		text = "{";
 		text = text .. "\"roster\": [";
@@ -1612,17 +1612,17 @@ function CEPGP_checkVersion(message)
 	build = string.sub(build, string.len(major)+2);
 	local minor = string.sub(build, 0, string.find(build, "%.")-1);
 	build = string.sub(build, string.find(build, "%.")+1);
-	
+
 	--Current build information
 	local curBuild = CEPGP_VERSION;
 	local curMajor = string.sub(curBuild, 0, string.find(curBuild, "%.")-1);
 	curBuild = string.sub(curBuild, string.len(curMajor)+2);
 	local curMinor = string.sub(curBuild, 0, string.find(curBuild, "%.")-1);
 	curBuild = string.sub(curBuild, string.find(curBuild, "%.")+1);
-	
+
 	outMessage = "Your addon is out of date. Version " .. major .. "." .. minor .. "." .. build .. " is now available for download at https://github.com/Alumian/CEPGP-Retail"
 	if not CEPGP_VERSION_NOTIFIED then
-		if tonumber(major) > tonumber(curMajor) then 
+		if tonumber(major) > tonumber(curMajor) then
 			CEPGP_print(outMessage);
 			CEPGP_VERSION_NOTIFIED = true;
 		elseif tonumber(major) == tonumber(curMajor) and tonumber(minor) > tonumber(curMinor) then


### PR DESCRIPTION
* Added verbose traffic logging option
![image](https://user-images.githubusercontent.com/20717031/69929203-6bc7a380-147b-11ea-830c-f1f5d6b33500.png)
* Reworked CEPGP_AddRaidEP message logic
* If the verbose traffic option is set, then each individual raid member is shown in the traffic log
* If the verbose traffic option is not set, then the log behaves the same as the current version of the addon
![image](https://user-images.githubusercontent.com/20717031/69929340-eabcdc00-147b-11ea-886b-6b5aa61040ca.png)
