### PR TITLE
CEPGP GP Rounding

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -801,9 +801,9 @@ function CEPGP_decay(amount, msg)
 			else]]
 				EP = math.floor(tonumber(EP)*(1-(amount/100)));
 				if CEPGP_minGPDecayFactor then
-					GP = math.floor((tonumber((GP-BASEGP))*(1-(amount/100)))+BASEGP);
+					GP = CEPGP_round((tonumber((GP-BASEGP))*(1-(amount/100)))+BASEGP);
 				else
-					GP = math.floor((tonumber(GP)*(1-(amount/100))));
+					GP = CEPGP_round((tonumber(GP)*(1-(amount/100))));
 				end
 				if GP < BASEGP then
 					GP = BASEGP;

--- a/Utility.lua
+++ b/Utility.lua
@@ -1685,3 +1685,7 @@ function CEPGP_sendChatMessage(msg, channel)
 		SendChatMessage(msg, channel, CEPGP_LANGUAGE);
 	end
 end
+
+function CEPGP_round(n)
+	return n % 1 >= 0.5 and math.ceil(n) or math.floor(n)
+end


### PR DESCRIPTION
Great addon!

A small thing that we noticed in our guild is that the decay functionality affects GP strangely due to the use of math.floor on the GP. A guild mate of ours had their GP decay down from 7 to 5.95 which rounded all the way down to 5 which we thought seems like unintended behavior. 

I added a simple utility function which will round using the ceiling function if the remainder is greater or equal to 0.5, and floor if less than 0.5. This seems better rounding wise in my opinion. If this is how you intend the rounding to work please do tell, and if any other place would need to have "correct" rounding elsewhere that would also be appreciated to know about if this pull request is to be accepted.

Cheers.