### PR TITLE
Default MOD to 1000 to increase accuracy

### DIFF
--- a/Utility.lua
+++ b/Utility.lua
@@ -15,7 +15,7 @@ function CEPGP_initialise()
 		CEPGP_lootChannel = "RAID";
 	end
 	if MOD == nil then
-		MOD = 1;
+		MOD = 1000;
 	end
 	if COEF == nil then
 		COEF = 4.83;


### PR DESCRIPTION
Increasing the default MOD to 1000 will increase the accuracy significantly. We have noticed our priority rating fluctuate heavily when applying decay due to the rounding down and low integer values.

Ive added an image to show the effects of this change, especially priority over time.
https://i.imgur.com/eZ4SDxq.png